### PR TITLE
Use int64 format for EmployerId

### DIFF
--- a/src/main/openapi/employment/identifier/v1/employment-identifier-v1.yaml
+++ b/src/main/openapi/employment/identifier/v1/employment-identifier-v1.yaml
@@ -9,6 +9,7 @@ components:
     EmployerId:
       description: Definitive or provisional NSSO number, assigned to each registered employer or local or provincial administration.
       type: integer
+      format: int64
       minimum: 197
       maximum: 5999999999 
       # Provisional NSSO numbers start with 5, definitive numbers are maximum 9 digits long


### PR DESCRIPTION
use int64 format for EmployerId to increase compatibility with code generation tooling (long instead of integer)